### PR TITLE
Display Boards Horizontally and Improve Status of Guess Board

### DIFF
--- a/lib/console_user_interface.rb
+++ b/lib/console_user_interface.rb
@@ -10,9 +10,91 @@ class ConsoleUserInterface
     @prior_guess_result = nil
   end
 
-  def show_potential_fleet_board(fleet_board)
+  def rows
+    ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j"]
+  end
+  
+  def clear_view
     system("cls") || system("clear")
-    show_fleet_board(fleet_board)
+  end
+
+  def show_potential_fleet_board(fleet_board)
+    clear_view
+    str = line
+    str += "|                          FLEET BOARD                            |\n" 
+    str += line
+    str += "|     |  1  |  2  |  3  |  4  |  5  |  6  |  7  |  8  |  9  | 10  |\n"
+    str += line
+    rows.each do | row |
+      str += stringify_fleet_board_row(row, fleet_board) + "\n" + line
+    end
+    output_stream.render(str)
+  end
+
+  def show_boards(guess_board, fleet_board)
+    clear_view
+    str = double_line
+    str += "|                          GUESS BOARD                            | * |                          FLEET BOARD                            |\n" 
+    str += double_line
+    str += "|     |  1  |  2  |  3  |  4  |  5  |  6  |  7  |  8  |  9  | 10  | * |     |  1  |  2  |  3  |  4  |  5  |  6  |  7  |  8  |  9  | 10  |\n"
+    str += double_line
+    rows.each do | row |
+      str += stringify_guess_board_row(row, guess_board)
+      str += " * "
+      str += stringify_fleet_board_row(row, fleet_board)
+      str += "\n"
+      str += double_line
+    end
+    output_stream.render(str)
+  end
+  
+  def stringify_guess_board_row(row, guess_board)
+    str = "|  #{row}  |"
+    guess_board.data[row.to_sym].each do | column |
+      str += guess_board_column_value_to_string(column) 
+    end
+    str
+  end
+
+  def guess_board_column_value_to_string(column)
+    if column == true
+      "  \e[31m#{"X"}\e[0m  |"
+    elsif column == false
+      "  \e[36m#{"-"}\e[0m  |"
+    else
+      "     |"
+    end
+  end
+
+  def stringify_fleet_board_row(row, fleet_board)
+    str = "|  #{row}  |"
+    fleet_board.data[row.to_sym].each do | column |
+      str += fleet_board_column_value_to_string(column)
+    end
+    str
+  end
+  
+  def fleet_board_column_value_to_string(column)
+    if column.is_a?(ShipSegment)
+      segment_string = "[#{column.ship.type[0]}]"
+      if column.hit?
+        " \e[31m#{segment_string}\e[0m |"
+      else  
+        " #{segment_string} |"
+      end
+    elsif column == false
+      "  \e[36m#{"-"}\e[0m  |"
+    else
+      "     |"
+    end
+  end
+  
+  def line
+    "|-----------------------------------------------------------------|\n"
+  end
+
+  def double_line
+    "|-----------------------------------------------------------------| * |-----------------------------------------------------------------|\n"
   end
 
   def get_board_ok
@@ -80,70 +162,6 @@ class ConsoleUserInterface
     end
   end
   
-  def clear_view
-    system("cls") || system("clear")
-  end
-
-  def show_guess_board(guess_board_data)
-    str =   "                             GUESS BOARD                          \n"
-    str += line_break
-    str +=  "     |  1  |  2  |  3  |  4  |  5  |  6  |  7  |  8  |  9  | 10  |\n"
-    str += line_break
-    guess_board_data.data.each do | row, columns |
-      str += "  #{row}  |"
-      columns.each do | column |
-        str += column_value_to_string(column)
-      end
-      str += "\n" + line_break
-    end
-    output_stream.render(str)
-    output_stream.render(@prior_guess_result)
-  end
-
-  def column_value_to_string(column)
-    if column == true
-      "  \e[31m#{"X"}\e[0m  |"
-    elsif column == false
-      "  \e[36m#{"-"}\e[0m  |"
-    else
-      "     |"
-    end
-  end
-
-  def show_fleet_board(fleet_board)
-    str =   "                              FLEET BOARD                          \n"
-    str += line_break
-    str +=  "\n     |  1  |  2  |  3  |  4  |  5  |  6  |  7  |  8  |  9  | 10  |\n"
-    str += line_break
-    fleet_board.data.each do | row, columns |
-      str += "  #{row}  |"
-      columns.each do | column |
-        str += fleet_column_value_to_string(column)
-      end
-      str += "\n" + line_break
-    end
-    output_stream.render(str)
-  end
-
-  def fleet_column_value_to_string(column)
-    if column.is_a?(ShipSegment)
-      segment_string = "[#{column.ship.type[0]}]"
-      if column.hit?
-        " \e[31m#{segment_string}\e[0m |"
-      else  
-        " #{segment_string} |"
-      end
-    elsif column == false
-      "  \e[36m#{"-"}\e[0m  |"
-    else
-      "     |"
-    end
-  end
-
-  def line_break
-    "------------------------------------------------------------------\n"
-  end
-  
   def announce_winner(winner)
     if winner.is_a?(HumanPlayer)
       output_stream.render("\nCongratulations! You won!\n")
@@ -172,4 +190,5 @@ class ConsoleUserInterface
   def good_bye
     output_stream.render("\nThanks for playing! Good bye!\n")
   end
+
 end

--- a/lib/console_user_interface.rb
+++ b/lib/console_user_interface.rb
@@ -7,7 +7,7 @@ class ConsoleUserInterface
   def initialize(output_stream:, input_stream:)
     @output_stream = output_stream
     @input_stream = input_stream
-    @prior_guess_result = nil
+    @status = ""
   end
 
   def rows
@@ -48,7 +48,9 @@ class ConsoleUserInterface
     str += "              Unsunk Ships                  Sunk Ships                              Unsunk Ships                  Sunk Ships \n"
     str += "              ------------                  ----------                              ------------                  ---------- \n"
     str += stringify_ships_list(guess_board, fleet_board)
-
+    str += double_line
+    str += "Status: \n"
+    str += @status
     output_stream.render(str)
   end
   
@@ -184,13 +186,17 @@ class ConsoleUserInterface
     column.to_i >= 1 && column.to_i <= 10
   end
   
-  def record_result_of_guess(coordinate_guess, guess_response)
+  def show_result_of_guess(coordinate_guess, guess_response)
     row = coordinate_guess.row
     column = coordinate_guess.column
     if guess_response.hit?
-      @prior_guess_result = "\n#{row}#{column} was a hit!\n"
+      @status = "\n#{row}#{column} was a hit!\n"
     else
-      @prior_guess_result = "\n#{row}#{column} was a miss!\n"
+      @status = "\n#{row}#{column} was a miss!\n"
+    end
+
+    if guess_response.ship_sunk?
+       @status += "\n** You sunk the computer's #{guess_response.ship_type}! **\n"
     end
   end
   

--- a/lib/console_user_interface.rb
+++ b/lib/console_user_interface.rb
@@ -45,6 +45,10 @@ class ConsoleUserInterface
       str += "\n"
       str += double_line
     end
+    str += "              Unsunk Ships                  Sunk Ships                              Unsunk Ships                  Sunk Ships \n"
+    str += "              ------------                  ----------                              ------------                  ---------- \n"
+    str += stringify_ships_list(guess_board, fleet_board)
+
     output_stream.render(str)
   end
   
@@ -95,6 +99,34 @@ class ConsoleUserInterface
 
   def double_line
     "|-----------------------------------------------------------------| * |-----------------------------------------------------------------|\n"
+  end
+
+  def stringify_ships_list(guess_board, fleet_board)
+    str = ""
+    (0..4).each do | index |
+      unsunk_guess_board_ship = stringify_unsunk_ship(guess_board.unsunk_ships[index])
+      sunk_guess_board_ship = stringify_sunk_ship(guess_board.sunk_ships[index])
+      str += "              " + unsunk_guess_board_ship + sunk_guess_board_ship + "\n"
+    end
+    str 
+  end
+
+  def stringify_unsunk_ship(unsunk_ship_string)
+    if unsunk_ship_string
+      padding = 30 - unsunk_ship_string.length
+      padding.times { unsunk_ship_string += " " }
+      unsunk_ship_string
+    else
+      "                              "
+    end
+  end
+
+  def stringify_sunk_ship(sunk_ship_string)
+    if sunk_ship_string
+      sunk_ship_string
+    else
+      "                               "
+    end
   end
 
   def get_board_ok

--- a/lib/guess_board.rb
+++ b/lib/guess_board.rb
@@ -1,6 +1,6 @@
 class GuessBoard
 
-  attr_reader :data
+  attr_reader :data, :unsunk_ships, :sunk_ships
   
   def initialize
     @data = 
@@ -16,12 +16,18 @@ class GuessBoard
         i: Array.new(10, nil),
         j: Array.new(10, nil)
       }
+    @unsunk_ships = ["Carrier", "Battleship", "Destroyer", "Submarine", "Patrol Boat"]
+    @sunk_ships = [ ]
   end
 
   def update_with(coordinate_guess, response)
     row = coordinate_guess.row.to_sym
     column = coordinate_guess.column.to_i - 1
     @data[row][column] = response.hit?
+    if response.ship_sunk?
+      sunk_ships.push(response.ship_type)
+      unsunk_ships.delete(response.ship_type)
+    end
   end
 
 end

--- a/lib/human_player.rb
+++ b/lib/human_player.rb
@@ -13,9 +13,7 @@ class HumanPlayer
   end
 
   def make_guess
-    user_interface.clear_view
-    user_interface.show_fleet_board(fleet_board)
-    user_interface.show_guess_board(guess_board)
+    user_interface.show_boards(guess_board, fleet_board)
     row = user_interface.get_row
     column = user_interface.get_column
     Coordinate.new(row, column)

--- a/lib/human_player.rb
+++ b/lib/human_player.rb
@@ -21,7 +21,7 @@ class HumanPlayer
   
   def note_response(coordinate_guess, guess_response)
     guess_board.update_with(coordinate_guess, guess_response)
-    user_interface.record_result_of_guess(coordinate_guess, guess_response)
+    user_interface.show_result_of_guess(coordinate_guess, guess_response)
   end
   
 end

--- a/spec/fake_user_interface.rb
+++ b/spec/fake_user_interface.rb
@@ -10,6 +10,10 @@ class FakeUserInterface
     @calls << :clear_view
   end
 
+  def show_boards(guess_board, fleet_board)
+    @calls << :show_boards
+  end
+
   def show_fleet_board(board)
     @calls << :show_fleet_board
   end

--- a/spec/fake_user_interface.rb
+++ b/spec/fake_user_interface.rb
@@ -32,8 +32,8 @@ class FakeUserInterface
     "1"
   end
 
-  def record_result_of_guess(coordinate_guess, guess_response)
-    @calls << :record_result_of_guess
+  def show_result_of_guess(coordinate_guess, guess_response)
+    @calls << :show_result_of_guess
   end
 
 end

--- a/spec/guess_board_spec.rb
+++ b/spec/guess_board_spec.rb
@@ -10,11 +10,24 @@ describe GuessBoard do
 
     it "parses row, column, and hit-status from its arguments coordinate_guess and response, and updates the data" do
       coordinate_guess = Coordinate.new("a", "1")
-      response = instance_double("GuessResponse", "hit?" => true)
+      response = instance_double("GuessResponse", "hit?" => true, "ship_sunk?" => false)
       
       guess_board.update_with(coordinate_guess, response)
 
       expect(guess_board.data[:a][0]).to eq(true)
+    end
+
+    it "updates the list of sunk ships and unsunk ships if the response indicates that a ship has been sunk" do
+      coordinate_guess = Coordinate.new("a", "1")
+      response = instance_double("GuessResponse")
+      allow(response).to receive("hit?").and_return(true)
+      allow(response).to receive("ship_sunk?").and_return(true)
+      allow(response).to receive("ship_type").and_return("Battleship")
+      
+      guess_board.update_with(coordinate_guess, response)
+
+      expect(guess_board.sunk_ships).to include("Battleship")
+      expect(guess_board.unsunk_ships).to eq(["Carrier", "Destroyer", "Submarine", "Patrol Boat"])
     end
 
   end

--- a/spec/human_player_spec.rb
+++ b/spec/human_player_spec.rb
@@ -57,12 +57,12 @@ describe HumanPlayer do
       human_player.note_response(coordinate_guess, guess_response)
     end
 
-    it "calls #record_result_of_guess on @user_interface and passes its own arguments for coordinate_guess and guess_response" do
+    it "calls #show_result_of_guess on @user_interface and passes its own arguments for coordinate_guess and guess_response" do
       coordinate_guess = double("coordinate guess")
       guess_response = double("guess response")
 
       human_player.note_response(coordinate_guess, guess_response)
-      expect(fake_user_interface.calls).to eq([:record_result_of_guess])
+      expect(fake_user_interface.calls).to eq([:show_result_of_guess])
     end
 
   end

--- a/spec/human_player_spec.rb
+++ b/spec/human_player_spec.rb
@@ -26,10 +26,10 @@ describe HumanPlayer do
 
   describe "#make_guess" do
 
-    it "refeshes the screen, shows the boards and asks the user for a row and column guess" do
+    it "shows the boards and asks the user for a row and column guess" do
       human_player.make_guess
 
-      expect(fake_user_interface.calls).to eq([:clear_view, :show_fleet_board, :show_guess_board, :get_row, :get_column])
+      expect(fake_user_interface.calls).to eq([:show_boards, :get_row, :get_column])
     end
 
     it "returns a coordinate object based on calling #get_row and #get_column on @user_interface" do


### PR DESCRIPTION
User's guess board and fleet board now display horizontally next to each other after user selects ship placement for fleet board.

In addition, user's guess board now has list of sunk and unsunk ships that updates as user sinks computer's ships. 

This also adds a status bar that updates with a message when user sinks a particular ship.

Idea for discussion: how to test a class such as ConsoleUserInterface that combines strings with an abstract output stream class.  Thanks